### PR TITLE
Auth 95: Identity Service 0.2

### DIFF
--- a/alfresco-anaxes-hello-world-ui-tar.xml
+++ b/alfresco-anaxes-hello-world-ui-tar.xml
@@ -11,7 +11,7 @@
       <directory>${basedir}/dist</directory>
       <outputDirectory>/</outputDirectory>
       <includes>
-        <include>**.*</include>
+        <include>**/*</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "ng2-alfresco-core": "1.9.0",
     "pdfjs-dist": "1.9.514",
     "rxjs": "5.1.0",
-    "zone.js": "0.8.14"
+    "zone.js": "0.8.14",
+    "angular-oauth2-oidc": "3.1.4"
   },
   "devDependencies": {
     "@angular/cli": "1.3.2",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { OAuthService } from 'angular-oauth2-oidc';
+import { JwksValidationHandler } from 'angular-oauth2-oidc';
+import { authConfig } from './auth.config';
 import { Component } from '@angular/core';
 import { AlfrescoTranslationService } from 'ng2-alfresco-core';
+import { Router } from "@angular/router";
 
 @Component({
   selector: 'app-root',
@@ -23,8 +27,14 @@ import { AlfrescoTranslationService } from 'ng2-alfresco-core';
 })
 export class AppComponent {
 
-  constructor(translationService: AlfrescoTranslationService) {
+  constructor(translationService: AlfrescoTranslationService, private oauthService: OAuthService) {
     translationService.use('en');
+    this.configureWithNewConfigApi();
   }
 
+  private configureWithNewConfigApi() {
+    this.oauthService.configure(authConfig);
+    this.oauthService.tokenValidationHandler = new JwksValidationHandler();
+    this.oauthService.loadDiscoveryDocumentAndLogin();
+  }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,8 +19,10 @@ import { RouterModule, Routes } from '@angular/router';
 import { AdfModule } from './adf.module';
 import { HomeComponent } from './home/home.component';
 import { AppComponent } from './app.component';
+import { AuthConfig, JwksValidationHandler, OAuthModule, ValidationHandler } from 'angular-oauth2-oidc';
 
-import {HttpModule} from '@angular/http';
+//import { HttpModule } from '@angular/http';
+import { HttpClientModule } from '@angular/common/http'
 
 const appRoutes: Routes = [
   { path: '', redirectTo: 'welcome', pathMatch: 'full' },
@@ -35,7 +37,8 @@ const appRoutes: Routes = [
       // { enableTracing: true } // <-- debugging purposes only
     ),
     AdfModule,
-    HttpModule
+    HttpClientModule,
+    OAuthModule.forRoot()
   ],
   declarations: [
     AppComponent,

--- a/src/app/auth.config.ts
+++ b/src/app/auth.config.ts
@@ -3,7 +3,7 @@ import { AuthConfig } from 'angular-oauth2-oidc';
 export const authConfig: AuthConfig = {
 
   // Url of the Identity Provider
-  issuer: 'http://localhost:8180/auth/realms/springboot',
+  issuer: 'http://localhost:8180/auth/realms/alfresco',
 
   // URL of the SPA to redirect the user to after login
   redirectUri: window.location.origin + '/index.html',
@@ -12,7 +12,7 @@ export const authConfig: AuthConfig = {
   silentRefreshRedirectUri: window.location.origin + '/index.html',
 
   // The SPA's id. The SPA is registered with this id at the auth-server
-  clientId: 'activiti',
+  clientId: 'alfresco',
 
   // set the scope for the permissions the client should request
   // The first three are defined by OIDC. The 4th is a usecase-specific one
@@ -20,5 +20,7 @@ export const authConfig: AuthConfig = {
 
   showDebugInformation: true,
 
-  sessionChecksEnabled: false
+  sessionChecksEnabled: false,
+
+  requireHttps: false
 }

--- a/src/app/auth.config.ts
+++ b/src/app/auth.config.ts
@@ -3,22 +3,22 @@ import { AuthConfig } from 'angular-oauth2-oidc';
 export const authConfig: AuthConfig = {
 
   // Url of the Identity Provider
-  issuer: 'http://localhost/auth/realms/springboot',
+  issuer: 'http://localhost:8180/auth/realms/springboot',
 
   // URL of the SPA to redirect the user to after login
   redirectUri: window.location.origin + '/index.html',
 
   // URL of the SPA to redirect the user after silent refresh
-  silentRefreshRedirectUri: window.location.origin + '/silent-refresh.html',
+  silentRefreshRedirectUri: window.location.origin + '/index.html',
 
-  // The SPA's id. The SPA is registerd with this id at the auth-server
+  // The SPA's id. The SPA is registered with this id at the auth-server
   clientId: 'activiti',
 
   // set the scope for the permissions the client should request
   // The first three are defined by OIDC. The 4th is a usecase-specific one
-  scope: 'openid profile email voucher',
+  scope: 'openid profile email',
 
   showDebugInformation: true,
 
-  sessionChecksEnabled: true
+  sessionChecksEnabled: false
 }

--- a/src/app/auth.config.ts
+++ b/src/app/auth.config.ts
@@ -1,0 +1,24 @@
+import { AuthConfig } from 'angular-oauth2-oidc';
+
+export const authConfig: AuthConfig = {
+
+  // Url of the Identity Provider
+  issuer: 'http://localhost/auth/realms/springboot',
+
+  // URL of the SPA to redirect the user to after login
+  redirectUri: window.location.origin + '/index.html',
+
+  // URL of the SPA to redirect the user after silent refresh
+  silentRefreshRedirectUri: window.location.origin + '/silent-refresh.html',
+
+  // The SPA's id. The SPA is registerd with this id at the auth-server
+  clientId: 'activiti',
+
+  // set the scope for the permissions the client should request
+  // The first three are defined by OIDC. The 4th is a usecase-specific one
+  scope: 'openid profile email voucher',
+
+  showDebugInformation: true,
+
+  sessionChecksEnabled: true
+}

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -12,3 +12,11 @@
   See the License for the specific language governing permissions and
   limitations under the License. -->
 <h3>{{msg}}</h3>
+<p>Alfresco Process Services</p>
+<div style="color: blueviolet">Last name: {{apsLastName}}</div>
+<p style="color:chocolate">Email: {{apsEmail}}</p>
+<p>{{apsError}}<p>
+<p>Alfresco Content Services<p>
+<div style="color: blueviolet">First name: {{acsFirstName}}</div>
+<p style="color:chocolate">Email: {{acsEmail}}</p>
+<p>{{acsError}}</p>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -18,6 +18,7 @@ import { Http, Response } from '@angular/http';
 import { AppConfigService } from 'ng2-alfresco-core';
 import 'rxjs/add/operator/map';
 import { ActivatedRoute } from '@angular/router';
+import { OAuthService } from "angular-oauth2-oidc";
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
@@ -32,8 +33,9 @@ export class HomeComponent {
   msg;
 
   constructor(private route: ActivatedRoute, private http:Http,
-        appConfig: AppConfigService) {
+        appConfig: AppConfigService, private oauthService: OAuthService) {
     this.apiUrl = appConfig.get('backEndHost') + '/hello/';
+    console.debug('access-token', this.oauthService.getAccessToken());
   }
 
   private ngOnInit() {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -72,7 +72,7 @@ export class HomeComponent {
     let apsURL="http://<ApsURL>/activiti-app/api/enterprise/profile";
     let acsURL="http://<AcsURL>/alfresco/api/-default-/public/alfresco/versions/1/people/-me-";
     let accessToken = this.oauthService.getAccessToken();
-    console.log('access-token', accessToken);
+    console.debug('access-token', accessToken);
     let myHeaders = new Headers();
     myHeaders.set("Authorization", "Bearer " + accessToken);
     let options = new RequestOptions({ headers: myHeaders });

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -29,6 +29,12 @@ export class HomeComponent {
   private id;
   private sub: any;
   private apiUrl;
+  apsLastName;
+  apsEmail;
+  acsFirstName;
+  acsEmail;
+  apsError;
+  acsError;
   data: any ={};
   msg;
 
@@ -41,7 +47,8 @@ export class HomeComponent {
     this.sub = this.route.params.subscribe(params => {
        this.id = params['id'];
       });
-     this.getResponse(this.id);
+    this.dbpEndpointsConsumtion();
+    //this.getResponse(this.id);
   }
 
   getResponse(id) {
@@ -61,4 +68,29 @@ export class HomeComponent {
          this.msg = 'ERROR: Something went wrong!';
        })
    }
+  dbpEndpointsConsumtion() {
+    let apsURL="http://<ApsURL>/activiti-app/api/enterprise/profile";
+    let acsURL="http://<AcsURL>/alfresco/api/-default-/public/alfresco/versions/1/people/-me-";
+    let accessToken = this.oauthService.getAccessToken();
+    console.log('access-token', accessToken);
+    let myHeaders = new Headers();
+    myHeaders.set("Authorization", "Bearer " + accessToken);
+    let options = new RequestOptions({ headers: myHeaders });
+    this.http.get(apsURL,options).
+      map((res: Response) => res.json()).subscribe(data => {
+        this.apsLastName=data.lastName;
+        this.apsEmail=data.email;
+      },
+      err => {
+        this.apsError = 'ERROR: Could not reach APS Endpoint!';
+      });
+    this.http.get(acsURL,options).
+      map((res: Response) => res.json()).subscribe(data => {
+        this.acsFirstName=data.entry.firstName;
+        this.acsEmail=data.entry.email;
+      },
+      err => {
+        this.acsError = 'ERROR: Could not reach ACS Endpoint!';
+      });  
+  }
 }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Component, OnInit } from '@angular/core';
-import { Http, Response } from '@angular/http';
+import { Http, Response, RequestOptions, Headers } from '@angular/http';
 import { AppConfigService } from 'ng2-alfresco-core';
 import 'rxjs/add/operator/map';
 import { ActivatedRoute } from '@angular/router';
@@ -34,12 +34,11 @@ export class HomeComponent {
 
   constructor(private route: ActivatedRoute, private http:Http,
         appConfig: AppConfigService, private oauthService: OAuthService) {
-    this.apiUrl = appConfig.get('backEndHost') + '/hello/';
-    console.debug('access-token', this.oauthService.getAccessToken());
+          this.apiUrl = appConfig.get('backEndHost') + '/hello/';
   }
 
   private ngOnInit() {
-     this.sub = this.route.params.subscribe(params => {
+    this.sub = this.route.params.subscribe(params => {
        this.id = params['id'];
       });
      this.getResponse(this.id);
@@ -47,7 +46,13 @@ export class HomeComponent {
 
   getResponse(id) {
      this.apiUrl += id;
-     return this.http.get(this.apiUrl).
+     console.debug("apiUrl", this.apiUrl);
+     let accessToken = this.oauthService.getAccessToken();
+     console.debug('access-token', accessToken);
+     let myHeaders = new Headers();
+     myHeaders.set("Authorization", "Bearer " + accessToken);
+     let options = new RequestOptions({ headers: myHeaders });
+     return this.http.get(this.apiUrl, options).
        map((res: Response) => res.json()).subscribe(data => {
          this.msg=data.value;
          this.data = data;


### PR DESCRIPTION
This PR contains the necessary changes to consume an ACS and an APS endpoint being authenticated with the same JWT by an instance of Keycloak that is configured with a SAML IdP provider.